### PR TITLE
Add output for Kubernetes cluster credentials

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,7 @@ resource "azurerm_kubernetes_cluster" "k8s_cluster" {
   }
 }
 
+
 # Output para obter credenciais do cluster
 output "kube_config" {
   value     = azurerm_kubernetes_cluster.k8s_cluster.kube_config_raw


### PR DESCRIPTION
Added a new Terraform output variable 'kube_config' to retrieve the raw Kubernetes configuration for the 'azurerm_kubernetes_cluster' resource. This facilitates easier access to the cluster credentials needed for administration and integration.