### PR TITLE
Update Azure subscription ID secret reference

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,5 +46,5 @@ jobs:
             - name: Terraform Apply
               if: github.ref == 'refs/heads/main'
               env:
-                  TF_VAR_subscription_id: ${{ secrets.SUBSCRIPTION_ID }}
+                  TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
               run: terraform apply -auto-approve tfplan


### PR DESCRIPTION
Renamed the secret reference from SUBSCRIPTION_ID to AZURE_SUBSCRIPTION_ID in the GitHub Actions workflow. This ensures the correct secret is used when running Terraform Apply on the main branch.