### PR TITLE
Remove unused output for Kubernetes public IP

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -206,9 +206,3 @@ output "kube_config" {
   value     = azurerm_kubernetes_cluster.k8s_cluster.kube_config_raw
   sensitive = true
 }
-
-# Output para obter o IP público do cluster Kubernetes
-output "kubernetes_cluster_public_ip" {
-  value = azurerm_kubernetes_cluster.k8s_cluster.kube_config.0.host
-}
-


### PR DESCRIPTION
The output block for `kubernetes_cluster_public_ip` was deleted as it is no longer required. This helps to clean up the Terraform configuration, improving maintainability and reducing confusion.