### PR TITLE
Add NGINX Ingress deployment via GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ permissions:
     id-token: write
     contents: read
 
+env:
+    RESOURCE_GROUP: 'rg-postech-fiap-k8s'
+    CLUSTER_NAME: 'postech-fiap-k8s-cluster'
+    
 jobs:
     terraform:
         runs-on: ubuntu-latest
@@ -64,3 +68,21 @@ jobs:
                   TF_VAR_mongodb_connection_string: ${{ secrets.MONGODB_CONNECTION_STRING }}
                   TF_VAR_azure_storage_connection_string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
               run: terraform apply -auto-approve tfplan
+
+            - name: 📥 Obter Configuração do Kubernetes
+              run: |
+                az aks get-credentials --resource-group ${{ env.RESOURCE_GROUP }} --name ${{ env.CLUSTER_NAME }} --overwrite-existing
+
+            - name: 📦 Instalar o Helm
+              uses: azure/setup-helm@v3
+
+            - name: 🚀 Deploy do Ingress NGINX no Kubernetes
+              run: |
+                helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+                helm repo update
+                helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+                  --namespace ingress-nginx \
+                  --create-namespace \
+                  --set controller.replicaCount=2 \
+                  --set controller.nodeSelector."kubernetes\.io/os"=linux \
+                  --set defaultBackend.nodeSelector."kubernetes\.io/os"=linux

--- a/main.tf
+++ b/main.tf
@@ -181,26 +181,6 @@ resource "kubernetes_config_map" "myfood_products_config" {
   }
 }
 
-# Adicionando o provedor Helm
-provider "helm" {
-  kubernetes {
-    host                   = azurerm_kubernetes_cluster.k8s_cluster.kube_config.0.host
-    client_certificate     = base64decode(azurerm_kubernetes_cluster.k8s_cluster.kube_config.0.client_certificate)
-    client_key             = base64decode(azurerm_kubernetes_cluster.k8s_cluster.kube_config.0.client_key)
-    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.k8s_cluster.kube_config.0.cluster_ca_certificate)
-  }
-}
-
-# Instalando o Helm Chart do Ingress NGINX
-resource "helm_release" "ingress_nginx" {
-  name       = "ingress-nginx"
-  chart      = "ingress-nginx"
-  repository = "helm_repository.ingress_nginx.url"
-  namespace  = "ingress-nginx"
-
-  create_namespace = true
-}
-
 # Output para obter credenciais do cluster
 output "kube_config" {
   value     = azurerm_kubernetes_cluster.k8s_cluster.kube_config_raw


### PR DESCRIPTION
Moved the Helm and NGINX Ingress setup from Terraform to GitHub Actions workflow. This improves automation flexibility and aligns better with CI/CD practices. Removed redundant Terraform configuration accordingly.