### PR TITLE
Set externalTrafficPolicy to Local in workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ permissions:
 env:
     RESOURCE_GROUP: 'rg-postech-fiap-k8s'
     CLUSTER_NAME: 'postech-fiap-k8s-cluster'
-    
+
 jobs:
     terraform:
         runs-on: ubuntu-latest
@@ -85,4 +85,5 @@ jobs:
                   --create-namespace \
                   --set controller.replicaCount=2 \
                   --set controller.nodeSelector."kubernetes\.io/os"=linux \
-                  --set defaultBackend.nodeSelector."kubernetes\.io/os"=linux
+                  --set defaultBackend.nodeSelector."kubernetes\.io/os"=linux \
+                  --set controller.service.externalTrafficPolicy=Local


### PR DESCRIPTION
This change updates the deployment configuration in the GitHub Actions workflow. Setting `controller.service.externalTrafficPolicy` to `Local` ensures that the source IP of incoming traffic is preserved.